### PR TITLE
Add more detailed span title

### DIFF
--- a/src/views/Dasboard.vue
+++ b/src/views/Dasboard.vue
@@ -192,7 +192,7 @@
               :background-color="'#78ddf4'"
               class="has-background-white">
               <template v-slot:title>
-                <span title="Number of users access per language">
+                <span title="Number of users access per language.">
                   Access per Language
                 </span>
               </template>
@@ -258,7 +258,7 @@
               class="has-background-white"
             >
               <template v-slot:title>
-                <span title="The number of registered reports grouped by report type(Question, level of confidence, etc)">
+                <span title="The number of registered reports grouped by report type(Question, level of confidence, etc).">
                   New Reports Registered
                 </span>
               </template>

--- a/src/views/Dasboard.vue
+++ b/src/views/Dasboard.vue
@@ -192,7 +192,7 @@
               :background-color="'#78ddf4'"
               class="has-background-white">
               <template v-slot:title>
-                <span title="Access per Language.">
+                <span title="Number of users access per language">
                   Access per Language
                 </span>
               </template>
@@ -258,7 +258,7 @@
               class="has-background-white"
             >
               <template v-slot:title>
-                <span title="The number of registered reports.">
+                <span title="The number of registered reports grouped by report type(Question, level of confidence, etc)">
                   New Reports Registered
                 </span>
               </template>
@@ -272,7 +272,7 @@
               class="has-background-white"
             >
               <template v-slot:title>
-                <span title="The number of registered reports.">
+                <span title="The number of registered reports grouped by which channel(Facebook, Telegram, etc) it were created by.">
                   Interaction by Channel
                 </span>
               </template>


### PR DESCRIPTION
Kaylan abriu um ticket pedindo uma descrição melhor dos títulos desses 3 gráficos:

#### Access per Language
- De: `Access per Language.`
- Para: `Number of users access per language`

#### New Reports Registered
- De: `The number of registered reports.`
- Para: `The number of registered reports grouped by report type(Question, level of confidence, etc).`

#### Interaction by Channel
- De: `The number of registered reports.`
- Para: `The number of registered reports grouped by which channel(Facebook, Telegram, etc) it were created by.`