### PR TITLE
fix: incoming and outgoing incorrect labels

### DIFF
--- a/src/mixins/dashboard.js
+++ b/src/mixins/dashboard.js
@@ -135,8 +135,8 @@ export default {
         this.totalErrors = this.countMessages(channelStatus, 'errors');
         const totalAsks = this.countMessages(channelStatus, 'incoming');
         this.messageMetricsData = this.makeMessageMetricsData(
-          totalAsks,
           this.totalAnswers,
+          totalAsks,
           this.totalErrors,
         );
         this.reportsData = this.makeReportsData(


### PR DESCRIPTION
The 'outgoing' type was being used as 'Incoming' label
And the 'incoming' type was being used as 'Sent' label